### PR TITLE
update types for lstm init state oneAPI

### DIFF
--- a/hls4ml/templates/oneapi/firmware/nnet_utils/nnet_recurrent.h
+++ b/hls4ml/templates/oneapi/firmware/nnet_utils/nnet_recurrent.h
@@ -611,10 +611,10 @@ void lstm_init_state(const data_T &data, const h_T &hidden_state_initial, const 
 
     [[intel::fpga_register]] h_T hidden_state[CONFIG_T::n_timesteps + 1];
     [[intel::fpga_register]] h_T hidden_state_temp;
-    [[intel::fpga_register]] h_T cell_state[CONFIG_T::n_timesteps + 1];
-    [[intel::fpga_register]] h_T cell_state_temp; // should this be updated to a differnt type
+    [[intel::fpga_register]] hc_T cell_state[CONFIG_T::n_timesteps + 1];
+    [[intel::fpga_register]] hc_T cell_state_temp; // should this be updated to a differnt type
     [[intel::fpga_register]] h_T h;
-    [[intel::fpga_register]] h_T c;
+    [[intel::fpga_register]] hc_T c;
     [[intel::fpga_register]] in_T in;
 
 // Set initially hidden state (output) to zero


### PR DESCRIPTION
# Description

This updates the types for oneAPI lstml.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Tests

For lstm, the tests succeed. For GRU (not part of this PR), there is an assertion error.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
