### PR TITLE
Fix pytorch simple RNN for oneAPI; add initial state version for Quartus and oneAPI

### DIFF
--- a/test/pytest/test_recurrent_pytorch.py
+++ b/test/pytest/test_recurrent_pytorch.py
@@ -171,7 +171,7 @@ class RNN(nn.Module):
         return output
 
 
-@pytest.mark.parametrize('backend', ['Quartus'])
+@pytest.mark.parametrize('backend', ['Quartus', 'oneAPI'])
 @pytest.mark.parametrize('io_type', ['io_parallel'])
 def test_rnn(backend, io_type):
     if not (backend in ('Quartus', 'oneAPI') and io_type == "io_stream"):


### PR DESCRIPTION
# Description

This adds the initial state version of simple RNN for Quartus and oneAPI and fixes the index order for accessing the hidden state arrays.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Fixes already failing tests

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
