### PR TITLE
fix simple-rnn config for Keras; make test names unique

### DIFF
--- a/hls4ml/backends/oneapi/passes/recurrent_templates.py
+++ b/hls4ml/backends/oneapi/passes/recurrent_templates.py
@@ -373,6 +373,9 @@ class SimpleRNNConfigTemplate(LayerConfigTemplate):
         )
         simple_rnn_params['recurrent_activation'] = 'relu'
 
+        # In Keras there is no recurrent bias, so put a placeholder
+        simple_rnn_params.setdefault('recurrent_bias_t', simple_rnn_params['bias_t'])
+
         simple_rnn_config = self.template.format(**simple_rnn_params)
 
         act_params = self._default_config_params(node)

--- a/test/pytest/test_qkeras.py
+++ b/test/pytest/test_qkeras.py
@@ -620,7 +620,7 @@ def test_qlstm(backend):
     config = hls4ml.utils.config_from_keras_model(
         model, granularity='name', default_precision="ap_fixed<8,1>", backend=backend
     )
-    output_dir = str(test_root_path / f'hls4mlprj_qkeras_qsimplernn_{backend}')
+    output_dir = str(test_root_path / f'hls4mlprj_qkeras_qlstm_{backend}')
     hls_model = hls4ml.converters.convert_from_keras_model(model, hls_config=config, output_dir=output_dir, backend=backend)
     hls_model.compile()
 


### PR DESCRIPTION
# Description

Put a dummy placeholder for recurrent_bias_t for Keras (where it is unused); fix pytest names to be unique

## Type of change

Note: Please delete options that are not relevant.

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

ran `pytest_rnn.py`, `pytest_qkeras`, and `pytest_recurrent_pytorch` successfully

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
