### PR TITLE
Fix simpleRNN config style, remove unused config

### DIFF
--- a/hls4ml/backends/oneapi/passes/recurrent_templates.py
+++ b/hls4ml/backends/oneapi/passes/recurrent_templates.py
@@ -322,7 +322,7 @@ class LSTMFunctionTemplate(FunctionCallTemplate):
 ################################################
 # SimpleRNN Template
 ################################################
-simple_rnn_config_template = """struct config{index} : nnet::simpleRNN_config {{
+simple_rnn_config_template = """struct config{index} : nnet::simple_rnn_config {{
     static const unsigned n_in = {n_in};
     static const unsigned n_out = {n_out};
     static const unsigned n_outputs = {n_outputs};

--- a/hls4ml/backends/quartus/passes/recurrent_templates.py
+++ b/hls4ml/backends/quartus/passes/recurrent_templates.py
@@ -258,7 +258,7 @@ class LSTMFunctionTemplate(FunctionCallTemplate):
 ################################################
 # SimpleRNN Template
 ################################################
-simple_rnn_config_template = """struct config{index} : nnet::simpleRNN_config {{
+simple_rnn_config_template = """struct config{index} : nnet::simple_rnn_config {{
     static const unsigned n_in = {n_in};
     static const unsigned n_out = {n_out};
     static const unsigned n_outputs = {n_outputs};

--- a/hls4ml/templates/oneapi/firmware/nnet_utils/nnet_recurrent.h
+++ b/hls4ml/templates/oneapi/firmware/nnet_utils/nnet_recurrent.h
@@ -247,7 +247,7 @@ void gru_init_state(const data_T &data, const h_T &hin, res_T &res, const typena
 // SimpleRNN
 //----------------------
 
-struct simpleRNN_config {
+struct simple_rnn_config {
     // Internal data type definitions
     typedef float weight_t;
     typedef float bias_t;
@@ -361,30 +361,6 @@ INIT_LOOP:
 //----------------------
 // SimpleRNN with pytorch biases
 //----------------------
-
-struct simpleRNN_pytorch_config {
-    // Internal data type definitions
-    typedef float weight_t;
-    typedef float bias_t;
-    typedef float accum_t;
-
-    // Layer Sizes
-    static const unsigned n_in = 1;
-    static const unsigned n_out = 1;
-    static const unsigned n_outputs = 1;
-    static const unsigned n_timesteps = 1;
-    static const bool return_sequences = false;
-
-    // Resource reuse info
-    static const unsigned io_type = io_parallel;
-    static const unsigned reuse_factor = 1;
-    static const bool store_weights_in_bram = false;
-
-    // Activation
-    template <class x_T, class y_T, class config_T> using activation_recr = nnet::activation::relu<x_T, y_T, config_T>;
-
-    template <class x_T, class y_T, class config_T> using activation = nnet::activation::relu<x_T, y_T, config_T>;
-};
 
 template <class in_T, class h_T, typename CONFIG_T>
 void simple_rnn_pytorch_cell(const in_T &inputs, h_T &hidden_state, h_T &hidden_state_o,

--- a/hls4ml/templates/quartus/firmware/nnet_utils/nnet_recurrent.h
+++ b/hls4ml/templates/quartus/firmware/nnet_utils/nnet_recurrent.h
@@ -251,7 +251,7 @@ void gru(data_T data[CONFIG_T::n_in], data2_T h[CONFIG_T::n_units], res_T res[CO
 // SimpleRNN
 //----------------------
 
-struct simpleRNN_config {
+struct simple_rnn_config {
     // Internal data type definitions
     typedef float weight_t;
     typedef float bias_t;
@@ -367,30 +367,6 @@ INIT_LOOP:
 //----------------------
 // SimpleRNN with pytorch biases
 //----------------------
-
-struct simpleRNN_pytorch_config {
-    // Internal data type definitions
-    typedef float weight_t;
-    typedef float bias_t;
-    typedef float accum_t;
-
-    // Layer Sizes
-    static const unsigned n_in = 1;
-    static const unsigned n_out = 1;
-    static const unsigned n_outputs = 1;
-    static const unsigned n_timesteps = 1;
-    static const bool return_sequences = false;
-
-    // Resource reuse info
-    static const unsigned io_type = io_parallel;
-    static const unsigned reuse_factor = 1;
-    static const bool store_weights_in_bram = false;
-
-    // Activation
-    template <class x_T, class y_T, class config_T> using activation_recr = nnet::activation::relu<x_T, y_T, config_T>;
-
-    template <class x_T, class y_T, class config_T> using activation = nnet::activation::relu<x_T, y_T, config_T>;
-};
 
 template <class data_T, class res_T, typename CONFIG_T>
 void simple_rnn_pytorch_cell(data_T inputs[CONFIG_T::n_in], res_T hidden_state[CONFIG_T::n_out],


### PR DESCRIPTION
# Description

This addresses one of the review questions from Vladimir. It changes `simpleRNN_config` to `simple_rnn_config`, and it removes the unused `simple_rnn_pytorch_config`. An alternate fix would be to actually use `simple_rnn_pytorch_config`, but I think that just adds complications.

## Type of change

- [x] Other (Specify) - cleanup

## Tests

Should have zero changes

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
